### PR TITLE
Update peerDependencies to support Grunt 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
-    "name":        "grunt-placeholder",
-    "homepage":    "https://github.com/JochenHoertreiter/grunt-placeholder",
+    "name": "grunt-placeholder",
+    "homepage": "https://github.com/JochenHoertreiter/grunt-placeholder",
     "description": "Grunt Task for replacing placeholders in source files with values from a configuration file",
-    "version":     "1.0.5",
-    "license":     "MIT",
+    "version": "1.0.5",
+    "license": "MIT",
     "author": {
-        "name":    "Jochen Hoertreiter",
-        "email":   "jochen.hoertreiter@googlemail.com",
-        "url":     "https://github.com/JochenHoertreiter"
+        "name": "Jochen Hoertreiter",
+        "email": "jochen.hoertreiter@googlemail.com",
+        "url": "https://github.com/JochenHoertreiter"
     },
     "keywords": [
         "placeholder",
@@ -19,27 +19,27 @@
     ],
     "repository": {
         "type": "git",
-        "url":  "https://github.com/JochenHoertreiter/grunt-placeholder"
+        "url": "https://github.com/JochenHoertreiter/grunt-placeholder"
     },
     "bugs": {
-        "url":  "https://github.com/JochenHoertreiter/grunt-placeholder/issues"
+        "url": "https://github.com/JochenHoertreiter/grunt-placeholder/issues"
     },
     "main": "Gruntfile.js",
     "devDependencies": {
-        "grunt":                "~0.4.5",
-        "grunt-cli":            "~0.1.13",
+        "grunt": "~0.4.5",
+        "grunt-cli": "~0.1.13",
         "grunt-contrib-jshint": "~0.11.2",
-        "grunt-contrib-clean":  "~0.6.0"
+        "grunt-contrib-clean": "~0.6.0"
     },
     "peerDependencies": {
-        "grunt":                "~0.4.5"
+        "grunt": ">=0.4.0"
     },
     "dependencies": {
-        "chalk":                "~1.0.0",
-        "ducky":                "~2.1.3",
-        "cache-lru":            "~1.0.6"
+        "chalk": "~1.0.0",
+        "ducky": "~2.1.3",
+        "cache-lru": "~1.0.6"
     },
     "engines": {
-        "node":                 ">=0.10.0"
+        "node": ">=0.10.0"
     }
 }


### PR DESCRIPTION
Update peerDependencies to support Grunt 1.0

Hello,

This is an automated issue request to update the `peerDependencies` for your Grunt plugin.
We ask you to merge this and **publish a new release on npm** to get your plugin working in Grunt 1.0!

Read more here: http://gruntjs.com/blog/2016-02-11-grunt-1.0.0-rc1-released#peer-dependencies
Also on Twitter: https://twitter.com/gruntjs/status/700819604155707392

If you have any questions or you no longer have time to maintain this plugin, then please let us know in this thread.

Thanks for creating and working on this plugin!

(P.S. Close this PR if it is a mistake, sorry)
